### PR TITLE
Update MBL and UBL

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -306,16 +306,13 @@ void unified_bed_leveling::G29() {
 
   const uint8_t p_val = parser.byteval('P');
   const bool may_move = p_val == 1 || p_val == 2 || p_val == 4 || parser.seen_test('J');
-  #if HAS_MULTI_HOTEND
-    const uint8_t old_tool_index = active_extruder;
-  #endif
 
   // Check for commands that require the printer to be homed
   if (may_move) {
     planner.synchronize();
     // Send 'N' to force homing before G29 (internal only)
     if (axes_should_home() || parser.seen_test('N')) gcode.home_all_axes();
-    TERN_(HAS_MULTI_HOTEND, if (active_extruder != 0) tool_change(0, true));
+    probe.use_probing_tool();
 
     // Position bed horizontally and Z probe vertically.
     #if    defined(SAFE_BED_LEVELING_START_X) || defined(SAFE_BED_LEVELING_START_Y) || defined(SAFE_BED_LEVELING_START_Z) \
@@ -698,7 +695,7 @@ void unified_bed_leveling::G29() {
     UNUSED(probe_deployed);
   #endif
 
-  TERN_(HAS_MULTI_HOTEND, if (old_tool_index != 0) tool_change(old_tool_index));
+  probe.use_probing_tool(false);
   return;
 }
 

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -103,9 +103,9 @@ void GcodeSuite::G29() {
       bedlevel.reset();
       mbl_probe_index = 0;
       if (!ui.wait_for_move) {
-        queue.inject(parser.seen_test('N') ? F("G28" TERN(CAN_SET_LEVELING_AFTER_G28, "L0", "") "\nG29S2") : F("G29S2"));
-        TERN_(EXTENSIBLE_UI, ExtUI::onLevelingStart());
-        TERN_(DWIN_LCD_PROUI, DWIN_LevelingStart());
+        probe.use_probing_tool();
+        if (parser.seen_test('N'))
+          queue.inject(F("G28" TERN_(CAN_SET_LEVELING_AFTER_G28, "L0")));
 
         // Position bed horizontally and Z probe vertically.
         #if    defined(SAFE_BED_LEVELING_START_X) || defined(SAFE_BED_LEVELING_START_Y) || defined(SAFE_BED_LEVELING_START_Z) \
@@ -142,6 +142,11 @@ void GcodeSuite::G29() {
 
           do_blocking_move_to(safe_position);
         #endif
+
+        queue.inject(F("G29S2"));
+
+        TERN_(EXTENSIBLE_UI, ExtUI::onLevelingStart());
+        TERN_(DWIN_LCD_PROUI, DWIN_LevelingStart());
 
         return;
       }
@@ -198,6 +203,7 @@ void GcodeSuite::G29() {
 
         home_all_axes();
         set_bed_leveling_enabled(true);
+        probe.use_probing_tool(false);
 
         #if ENABLED(MESH_G28_REST_ORIGIN)
           current_position.z = 0;

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -852,7 +852,8 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
     static uint8_t old_tool;
     static bool old_state = false;
     if (probing == old_state) return;
-    if ((old_state = probing)) old_tool = active_extruder;
+    old_state = probing;
+    if (probing) old_tool = active_extruder;
     const uint8_t tool = probing ? PROBING_TOOL : old_tool;
     if (tool != active_extruder)
       tool_change(tool, ENABLED(PROBE_TOOLCHANGE_NO_MOVE));


### PR DESCRIPTION
### Description

Use probe.use_probing_tool() in MBL and UBL G29.

### Requirements

MESH_BED_LEVELING or AUTO_BED_LEVELING_UBL

### Benefits

- change to T0 during MBL to prevent crashes when HOTEND_OFFSET_* of any tool is not 0
- Unified logic
- Also, fix MBL with `SAFE_BED_LEVELING_START_*`
 
### Configurations

None

### Related Issues
